### PR TITLE
Associated Reference Types

### DIFF
--- a/examples/ordered.rs
+++ b/examples/ordered.rs
@@ -23,7 +23,8 @@ impl<S> Ordered<S> {
 	pub fn try_push<T>(&mut self, element: T) -> Result<(), T>
 	where
 		T: PartialOrd,
-		S: Collection<Item=T> + Back + PushBack // `S` must be a stack providing `back` and `push_back`.
+		S: Collection<Item=T> + Back + PushBack, // `S` must be a stack providing `back` and `push_back`.
+		for<'a> S::ItemRef<'a>: PartialOrd<&'a T> // The reference type must be comparable with other reference types.
 	{
 		if self.inner.back().map(|back| back <= &element).unwrap_or(true) {
 			self.inner.push_back(element);

--- a/src/impls/slab.rs
+++ b/src/impls/slab.rs
@@ -1,6 +1,8 @@
 use slab::Slab;
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	WithCapacity,
 	Len,
 	Capacity,
@@ -14,6 +16,14 @@ use crate::{
 
 impl<T> Collection for Slab<T> {
 	type Item = T;
+}
+
+impl<T> CollectionRef for Slab<T> {
+	type ItemRef<'a> where Self: 'a = &'a T;
+}
+
+impl<T> CollectionMut for Slab<T> {
+	type ItemMut<'a> where Self: 'a = &'a mut T;
 }
 
 impl<T> WithCapacity for Slab<T> {
@@ -53,7 +63,7 @@ impl<T> GetMut<usize> for Slab<T> {
 }
 
 impl<T> Insert for Slab<T> {
-	type Output = usize;
+	type Output<'a> where Self: 'a = usize;
 
 	fn insert(&mut self, element: T) -> usize {
 		self.insert(element)

--- a/src/impls/smallvec.rs
+++ b/src/impls/smallvec.rs
@@ -4,6 +4,8 @@ use smallvec::{
 };
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	WithCapacity,
 	Len,
 	Capacity,
@@ -20,6 +22,14 @@ use crate::{
 
 impl<A: Array> Collection for SmallVec<A> {
 	type Item = A::Item;
+}
+
+impl<A: Array> CollectionRef for SmallVec<A> {
+	type ItemRef<'a> where Self: 'a = &'a A::Item;
+}
+
+impl<A: Array> CollectionMut for SmallVec<A> {
+	type ItemMut<'a> where Self: 'a = &'a mut A::Item;
 }
 
 impl<A: Array> WithCapacity for SmallVec<A> {
@@ -78,7 +88,7 @@ impl<A: Array> FrontMut for SmallVec<A> {
 }
 
 impl<A: Array> PushBack for SmallVec<A> {
-	type Output = ();
+	type Output<'a> where Self: 'a = ();
 
 	fn push_back(&mut self, t: A::Item) {
 		self.push(t)

--- a/src/impls/std_collections/btreemap.rs
+++ b/src/impls/std_collections/btreemap.rs
@@ -4,6 +4,8 @@ use std::{
 };
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	Len,
 	Get,
 	GetMut,
@@ -14,6 +16,14 @@ use crate::{
 
 impl<K, V> Collection for BTreeMap<K, V> {
 	type Item = V;
+}
+
+impl<K, V> CollectionRef for BTreeMap<K, V> {
+	type ItemRef<'a> where Self: 'a = &'a V;
+}
+
+impl<K, V> CollectionMut for BTreeMap<K, V> {
+	type ItemMut<'a> where Self: 'a = &'a mut V;
 }
 
 impl<K, V> Len for BTreeMap<K, V> {
@@ -42,8 +52,8 @@ impl<'a, Q, K: Ord, V> GetMut<&'a Q> for BTreeMap<K, V> where K: Borrow<Q>, Q: O
 	}
 }
 
-impl<'a, K: Ord, V> MapInsert<K> for BTreeMap<K, V> {
-	type Output = Option<V>;
+impl<K: Ord, V> MapInsert<K> for BTreeMap<K, V> {
+	type Output<'a> where Self: 'a = Option<V>;
 
 	#[inline(always)]
 	fn insert(&mut self, key: K, value: V) -> Option<V> {

--- a/src/impls/std_collections/btreeset.rs
+++ b/src/impls/std_collections/btreeset.rs
@@ -4,6 +4,8 @@ use std::{
 };
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	Len,
 	Get,
 	Insert,
@@ -13,6 +15,14 @@ use crate::{
 
 impl<T> Collection for BTreeSet<T> {
 	type Item = T;
+}
+
+impl<T> CollectionRef for BTreeSet<T> {
+	type ItemRef<'a> where Self: 'a = &'a T;
+}
+
+impl<T> CollectionMut for BTreeSet<T> {
+	type ItemMut<'a> where Self: 'a = &'a mut T;
 }
 
 impl<T> Len for BTreeSet<T> {
@@ -34,8 +44,8 @@ impl<'a, Q, T: Ord> Get<&'a Q> for BTreeSet<T> where T: Borrow<Q>, Q: Ord + ?Siz
 	}
 }
 
-impl<'a, T: Ord> Insert for BTreeSet<T> {
-	type Output = bool;
+impl<T: Ord> Insert for BTreeSet<T> {
+	type Output<'a> where Self: 'a = bool;
 
 	#[inline(always)]
 	fn insert(&mut self, t: T) -> bool {

--- a/src/impls/std_collections/deque.rs
+++ b/src/impls/std_collections/deque.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	WithCapacity,
 	Len,
 	Capacity,
@@ -16,6 +18,14 @@ use crate::{
 
 impl<T> Collection for VecDeque<T> {
 	type Item = T;
+}
+
+impl<T> CollectionRef for VecDeque<T> {
+	type ItemRef<'a> where Self: 'a = &'a T;
+}
+
+impl<T> CollectionMut for VecDeque<T> {
+	type ItemMut<'a> where Self: 'a = &'a mut T;
 }
 
 impl<T> WithCapacity for VecDeque<T> {
@@ -74,7 +84,7 @@ impl<T> FrontMut for VecDeque<T> {
 }
 
 impl<T> PushBack for VecDeque<T> {
-	type Output = ();
+	type Output<'a> where Self: 'a = ();
 
 	fn push_back(&mut self, t: T) {
 		self.push_back(t)

--- a/src/impls/std_collections/hashmap.rs
+++ b/src/impls/std_collections/hashmap.rs
@@ -5,6 +5,8 @@ use std::{
 };
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	Len,
 	Get,
 	GetMut,
@@ -15,6 +17,14 @@ use crate::{
 
 impl<K, V> Collection for HashMap<K, V> {
 	type Item = V;
+}
+
+impl<K, V> CollectionRef for HashMap<K, V> {
+	type ItemRef<'a> where Self: 'a = &'a V;
+}
+
+impl<K, V> CollectionMut for HashMap<K, V> {
+	type ItemMut<'a> where Self: 'a = &'a mut V;
 }
 
 impl<K, V> Len for HashMap<K, V> {
@@ -43,8 +53,8 @@ impl<'a, Q, K: Hash + Eq, V> GetMut<&'a Q> for HashMap<K, V> where K: Borrow<Q>,
 	}
 }
 
-impl<'a, K: Hash + Eq, V> MapInsert<K> for HashMap<K, V> {
-	type Output = Option<V>;
+impl<K: Hash + Eq, V> MapInsert<K> for HashMap<K, V> {
+	type Output<'a> where Self: 'a = Option<V>;
 
 	#[inline(always)]
 	fn insert(&mut self, key: K, value: V) -> Option<V> {

--- a/src/impls/std_collections/hashset.rs
+++ b/src/impls/std_collections/hashset.rs
@@ -5,6 +5,8 @@ use std::{
 };
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	Len,
 	Get,
 	Insert,
@@ -14,6 +16,14 @@ use crate::{
 
 impl<T> Collection for HashSet<T> {
 	type Item = T;
+}
+
+impl<T> CollectionRef for HashSet<T> {
+	type ItemRef<'a> where Self: 'a = &'a T;
+}
+
+impl<T> CollectionMut for HashSet<T> {
+	type ItemMut<'a> where Self: 'a = &'a mut T;
 }
 
 impl<T> Len for HashSet<T> {
@@ -34,8 +44,8 @@ impl<'a, Q, T: Hash + Eq> Get<&'a Q> for HashSet<T> where T: Borrow<Q>, Q: Hash 
 	}
 }
 
-impl<'a, T: Hash + Eq> Insert for HashSet<T> {
-	type Output = bool;
+impl<T: Hash + Eq> Insert for HashSet<T> {
+	type Output<'a> where Self: 'a = bool;
 
 	#[inline(always)]
 	fn insert(&mut self, t: T) -> bool {

--- a/src/impls/std_collections/vec.rs
+++ b/src/impls/std_collections/vec.rs
@@ -1,5 +1,7 @@
 use crate::{
 	Collection,
+	CollectionRef,
+	CollectionMut,
 	WithCapacity,
 	Len,
 	Capacity,
@@ -16,6 +18,14 @@ use crate::{
 
 impl<T> Collection for Vec<T> {
 	type Item = T;
+}
+
+impl<T> CollectionRef for Vec<T> {
+	type ItemRef<'a> where Self: 'a = &'a T;
+}
+
+impl<T> CollectionMut for Vec<T> {
+	type ItemMut<'a> where Self: 'a = &'a mut T;
 }
 
 impl<T> WithCapacity for Vec<T> {
@@ -74,7 +84,7 @@ impl<T> FrontMut for Vec<T> {
 }
 
 impl<T> PushBack for Vec<T> {
-	type Output = ();
+	type Output<'a> where Self: 'a = ();
 
 	fn push_back(&mut self, t: T) {
 		self.push(t)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@
 //! 	pub fn try_push<T>(&mut self, element: T) -> Result<(), T>
 //! 	where
 //! 		T: PartialOrd,
-//! 		S: Collection<Item=T> + Back + PushBack // `S` must be a stack providing `back` and `push_back`.
+//! 		S: Collection<Item=T> + Back + PushBack, // `S` must be a stack providing `back` and `push_back`.
+//! 		for<'a> S::ItemRef<'a>: PartialOrd<&'a T> // The reference type must be comparable with other reference types.
 //! 	{
 //! 		if self.inner.back().map(|back| back <= &element).unwrap_or(true) {
 //! 			self.inner.push_back(element);


### PR DESCRIPTION
I have added different associated types for the reference types returned from trait methods such as `Get::get`, using generic associated types to enable patterns such as collections that return guarded references. I've done this in anticipation of Rust stabilizing GATs soon, as their [blog post](https://blog.rust-lang.org/2021/08/03/GATs-stabilization-push.html) has led me to believe. To further emphasize the pattern of collections that are locks, I've added `Lock` traits which provide the same interface as their non-`Lock` counterparts, only behind an immutable reference rather than a mutable one. To showcase these new features I've also added implementations for the traits on structures in the popular [dashmap crate](https://crates.io/crates/dashmap).

I'll ready this pull request if and when (hopefully just a matter of when) GATs are stabilized.