### PR TITLE
Add `SimpleKeyedRef` helper trait, implement `SimpleXxx` traits using macros

### DIFF
--- a/examples/ordered.rs
+++ b/examples/ordered.rs
@@ -3,6 +3,7 @@ use cc_traits::{Back, Collection, PushBack};
 use std::collections::VecDeque;
 
 /// Ordered stack.
+#[derive(Default)]
 pub struct Ordered<S> {
 	inner: S,
 }
@@ -12,9 +13,7 @@ impl<S> Ordered<S> {
 	where
 		S: Default,
 	{
-		Ordered {
-			inner: S::default(),
-		}
+		Default::default()
 	}
 }
 

--- a/src/impls/alloc/btreemap.rs
+++ b/src/impls/alloc/btreemap.rs
@@ -1,7 +1,7 @@
 use crate::{
 	Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetMut, Iter, Keyed,
 	KeyedRef, Len, MapInsert, MapIter, MapIterMut, Remove, SimpleCollectionMut,
-	SimpleCollectionRef,
+	SimpleCollectionRef, SimpleKeyedRef,
 };
 use alloc::collections::BTreeMap;
 use core::borrow::Borrow;
@@ -48,6 +48,15 @@ impl<K, V> KeyedRef for BTreeMap<K, V> {
 	type KeyRef<'a> = &'a K where Self: 'a;
 
 	crate::covariant_key_ref!();
+}
+
+impl<K, V> SimpleKeyedRef for BTreeMap<K, V> {
+	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+	where
+		Self: 'r,
+	{
+		r
+	}
 }
 
 impl<K, V> Len for BTreeMap<K, V> {

--- a/src/impls/alloc/btreemap.rs
+++ b/src/impls/alloc/btreemap.rs
@@ -23,21 +23,11 @@ impl<K, V> CollectionMut for BTreeMap<K, V> {
 }
 
 impl<K, V> SimpleCollectionRef for BTreeMap<K, V> {
-	fn into_ref<'a>(r: &'a V) -> &'a V
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<K, V> SimpleCollectionMut for BTreeMap<K, V> {
-	fn into_mut<'a>(r: &'a mut V) -> &'a mut V
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<K, V> Keyed for BTreeMap<K, V> {
@@ -51,12 +41,7 @@ impl<K, V> KeyedRef for BTreeMap<K, V> {
 }
 
 impl<K, V> SimpleKeyedRef for BTreeMap<K, V> {
-	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
-	where
-		Self: 'r,
-	{
-		r
-	}
+	crate::simple_keyed_ref!();
 }
 
 impl<K, V> Len for BTreeMap<K, V> {

--- a/src/impls/alloc/btreeset.rs
+++ b/src/impls/alloc/btreeset.rs
@@ -22,21 +22,11 @@ impl<T> CollectionMut for BTreeSet<T> {
 }
 
 impl<T> SimpleCollectionRef for BTreeSet<T> {
-	fn into_ref<'a>(r: &'a T) -> &'a T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<T> SimpleCollectionMut for BTreeSet<T> {
-	fn into_mut<'a>(r: &'a mut T) -> &'a mut T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<T> Len for BTreeSet<T> {

--- a/src/impls/alloc/deque.rs
+++ b/src/impls/alloc/deque.rs
@@ -21,21 +21,11 @@ impl<T> CollectionMut for VecDeque<T> {
 }
 
 impl<T> SimpleCollectionRef for VecDeque<T> {
-	fn into_ref<'a>(r: &'a T) -> &'a T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<T> SimpleCollectionMut for VecDeque<T> {
-	fn into_mut<'a>(r: &'a mut T) -> &'a mut T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<T> WithCapacity for VecDeque<T> {

--- a/src/impls/alloc/vec.rs
+++ b/src/impls/alloc/vec.rs
@@ -21,21 +21,11 @@ impl<T> CollectionMut for Vec<T> {
 }
 
 impl<T> SimpleCollectionRef for Vec<T> {
-	fn into_ref<'a>(r: &'a T) -> &'a T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<T> SimpleCollectionMut for Vec<T> {
-	fn into_mut<'a>(r: &'a mut T) -> &'a mut T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<T> WithCapacity for Vec<T> {

--- a/src/impls/ijson.rs
+++ b/src/impls/ijson.rs
@@ -22,21 +22,11 @@ impl CollectionMut for IObject {
 }
 
 impl SimpleCollectionRef for IObject {
-	fn into_ref<'a>(r: &'a IValue) -> &'a IValue
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl SimpleCollectionMut for IObject {
-	fn into_mut<'a>(r: &'a mut IValue) -> &'a mut IValue
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl Keyed for IObject {
@@ -50,12 +40,7 @@ impl KeyedRef for IObject {
 }
 
 impl SimpleKeyedRef for IObject {
-	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
-	where
-		Self: 'r,
-	{
-		r
-	}
+	crate::simple_keyed_ref!();
 }
 
 impl Len for IObject {

--- a/src/impls/ijson.rs
+++ b/src/impls/ijson.rs
@@ -1,7 +1,7 @@
 use crate::{
 	Capacity, Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetKeyValueMut,
 	GetMut, Iter, IterMut, Keyed, KeyedRef, Len, MapInsert, MapIter, MapIterMut, PopBack, PushBack,
-	Remove, Reserve, SimpleCollectionMut, SimpleCollectionRef, WithCapacity,
+	Remove, Reserve, SimpleCollectionMut, SimpleCollectionRef, SimpleKeyedRef, WithCapacity,
 };
 use ijson::{IArray, IObject, IString, IValue};
 
@@ -47,6 +47,15 @@ impl KeyedRef for IObject {
 	type KeyRef<'a> = &'a IString where Self: 'a;
 
 	crate::covariant_key_ref!();
+}
+
+impl SimpleKeyedRef for IObject {
+	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+	where
+		Self: 'r,
+	{
+		r
+	}
 }
 
 impl Len for IObject {

--- a/src/impls/serde_json.rs
+++ b/src/impls/serde_json.rs
@@ -22,12 +22,7 @@ impl CollectionMut for serde_json::Map<String, serde_json::Value> {
 }
 
 impl SimpleCollectionRef for serde_json::Map<String, serde_json::Value> {
-	fn into_ref<'a>(r: &'a serde_json::Value) -> &'a serde_json::Value
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl SimpleCollectionMut for serde_json::Map<String, serde_json::Value> {
@@ -50,12 +45,7 @@ impl KeyedRef for serde_json::Map<String, serde_json::Value> {
 }
 
 impl SimpleKeyedRef for serde_json::Map<String, serde_json::Value> {
-	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
-	where
-		Self: 'r,
-	{
-		r
-	}
+	crate::simple_keyed_ref!();
 }
 
 impl Len for serde_json::Map<String, serde_json::Value> {

--- a/src/impls/serde_json.rs
+++ b/src/impls/serde_json.rs
@@ -1,6 +1,7 @@
 use crate::{
 	Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetMut, Keyed, KeyedRef,
 	Len, MapInsert, MapIter, MapIterMut, Remove, SimpleCollectionMut, SimpleCollectionRef,
+	SimpleKeyedRef,
 };
 use std::{borrow::Borrow, cmp::Ord, hash::Hash};
 
@@ -46,6 +47,15 @@ impl KeyedRef for serde_json::Map<String, serde_json::Value> {
 	type KeyRef<'a> = &'a String where Self: 'a;
 
 	crate::covariant_key_ref!();
+}
+
+impl SimpleKeyedRef for serde_json::Map<String, serde_json::Value> {
+	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+	where
+		Self: 'r,
+	{
+		r
+	}
 }
 
 impl Len for serde_json::Map<String, serde_json::Value> {

--- a/src/impls/slab.rs
+++ b/src/impls/slab.rs
@@ -21,21 +21,11 @@ impl<T> CollectionMut for Slab<T> {
 }
 
 impl<T> SimpleCollectionRef for Slab<T> {
-	fn into_ref<'a>(r: &'a T) -> &'a T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<T> SimpleCollectionMut for Slab<T> {
-	fn into_mut<'a>(r: &'a mut T) -> &'a mut T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<T> WithCapacity for Slab<T> {

--- a/src/impls/smallvec.rs
+++ b/src/impls/smallvec.rs
@@ -21,21 +21,11 @@ impl<A: Array> CollectionMut for SmallVec<A> {
 }
 
 impl<A: Array> SimpleCollectionRef for SmallVec<A> {
-	fn into_ref<'a>(r: &'a A::Item) -> &'a A::Item
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<A: Array> SimpleCollectionMut for SmallVec<A> {
-	fn into_mut<'a>(r: &'a mut A::Item) -> &'a mut A::Item
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<A: Array> WithCapacity for SmallVec<A> {

--- a/src/impls/std/hashmap.rs
+++ b/src/impls/std/hashmap.rs
@@ -1,7 +1,7 @@
 use crate::{
 	Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetMut, Iter, Keyed,
 	KeyedRef, Len, MapInsert, MapIter, MapIterMut, Remove, SimpleCollectionMut,
-	SimpleCollectionRef,
+	SimpleCollectionRef, SimpleKeyedRef,
 };
 use std::{borrow::Borrow, collections::HashMap, hash::Hash};
 
@@ -47,6 +47,15 @@ impl<K, V> KeyedRef for HashMap<K, V> {
 	type KeyRef<'a> = &'a K where Self: 'a;
 
 	crate::covariant_key_ref!();
+}
+
+impl<K, V> SimpleKeyedRef for HashMap<K, V> {
+	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+	where
+		Self: 'r,
+	{
+		r
+	}
 }
 
 impl<K, V> Len for HashMap<K, V> {

--- a/src/impls/std/hashmap.rs
+++ b/src/impls/std/hashmap.rs
@@ -22,21 +22,11 @@ impl<K, V> CollectionMut for HashMap<K, V> {
 }
 
 impl<K, V> SimpleCollectionRef for HashMap<K, V> {
-	fn into_ref<'a>(r: &'a V) -> &'a V
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<K, V> SimpleCollectionMut for HashMap<K, V> {
-	fn into_mut<'a>(r: &'a mut V) -> &'a mut V
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<K, V> Keyed for HashMap<K, V> {
@@ -50,12 +40,7 @@ impl<K, V> KeyedRef for HashMap<K, V> {
 }
 
 impl<K, V> SimpleKeyedRef for HashMap<K, V> {
-	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
-	where
-		Self: 'r,
-	{
-		r
-	}
+	crate::simple_keyed_ref!();
 }
 
 impl<K, V> Len for HashMap<K, V> {

--- a/src/impls/std/hashset.rs
+++ b/src/impls/std/hashset.rs
@@ -21,21 +21,11 @@ impl<T> CollectionMut for HashSet<T> {
 }
 
 impl<T> SimpleCollectionRef for HashSet<T> {
-	fn into_ref<'a>(r: &'a T) -> &'a T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_ref!();
 }
 
 impl<T> SimpleCollectionMut for HashSet<T> {
-	fn into_mut<'a>(r: &'a mut T) -> &'a mut T
-	where
-		Self: 'a,
-	{
-		r
-	}
+	crate::simple_collection_mut!();
 }
 
 impl<T> Len for HashSet<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,20 @@ pub trait KeyedRef: Keyed {
 		Self: 'long;
 }
 
+/// Keyed collection where each key reference can be converted into a standard
+/// "simple" rust reference.
+///
+/// This trait is particularly useful to avoid having to include where bounds
+/// of the form `for<'r> T::KeyRef<'r>: Into<&'r T::Key>`, which can
+/// currently lead the compiler to try to prove `T: 'static`
+/// (see https://github.com/rust-lang/rust/pull/96709#issuecomment-1182403490)
+/// for more details.
+pub trait SimpleKeyedRef: KeyedRef {
+	fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+	where
+		Self: 'r;
+}
+
 /// Collection that can be created with a minimum given capacity.
 pub trait WithCapacity {
 	/// Creates a new instance of `Self` with the given minimum capacity.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -100,3 +100,116 @@ macro_rules! covariant_key_ref {
 		}
 	};
 }
+
+/// Automatically defines the `CollectionMut::upcast_item_mut` function using the
+/// covariance of the `ItemMut<'a>` type with regards to `'a`.
+///
+/// ## Example
+///
+/// ```
+/// use cc_traits::{Collection, CollectionMut, SimpleCollectionMut, covariant_item_mut, simple_collection_mut};
+///
+/// pub struct MyVec<T>(Vec<T>);
+///
+/// impl<T> Collection for MyVec<T> {
+///   type Item = T;
+/// }
+///
+/// impl<T> CollectionMut for MyVec<T> {
+///   type ItemMut<'a>
+///   = &'a mut T where Self: 'a;
+///
+///   covariant_item_mut!();
+/// }
+///
+/// impl<T> SimpleCollectionMut for MyVec<T> {
+///   simple_collection_mut!();
+/// }
+/// ```
+#[macro_export]
+macro_rules! simple_collection_mut {
+	() => {
+		fn into_mut<'r>(r: Self::ItemMut<'r>) -> &'r mut Self::Item
+		where
+			Self: 'r,
+		{
+			r
+		}
+	};
+}
+
+/// Automatically defines the `SimpleCollectionRef::into_ref` function.
+///
+/// ## Example
+///
+/// ```
+/// use cc_traits::{Collection, CollectionRef, SimpleCollectionRef, covariant_item_ref, simple_collection_ref};
+///
+/// pub struct MyVec<T>(Vec<T>);
+///
+/// impl<T> Collection for MyVec<T> {
+///   type Item = T;
+/// }
+///
+/// impl<T> CollectionRef for MyVec<T> {
+///   type ItemRef<'a>
+///   = &'a T where Self: 'a;
+///
+///   covariant_item_ref!();
+/// }
+///
+/// impl<T> SimpleCollectionRef for MyVec<T> {
+///   simple_collection_ref!();
+/// }
+/// ```
+#[macro_export]
+macro_rules! simple_collection_ref {
+	() => {
+		fn into_ref<'r>(r: Self::ItemRef<'r>) -> &'r Self::Item
+		where
+			Self: 'r,
+		{
+			r
+		}
+	};
+}
+
+/// Automatically defines the `SimpleKeyedRef::into_ref` function.
+///
+/// ## Example
+///
+/// ```
+/// use cc_traits::{Collection, Keyed, KeyedRef, SimpleKeyedRef, covariant_key_ref, simple_keyed_ref};
+///
+/// pub struct MyMap<K, V>(std::collections::HashMap<K, V>);
+///
+/// impl<K, V> Collection for MyMap<K, V> {
+///   type Item = V;
+/// }
+///
+/// impl<K, V> Keyed for MyMap<K, V> {
+///   type Key = K;
+/// }
+///
+/// impl<K, V> KeyedRef for MyMap<K, V> {
+///   type KeyRef<'a>
+///   = &'a K where Self: 'a;
+///
+///   covariant_key_ref!();
+/// }
+///
+/// impl<K, V> SimpleKeyedRef for MyMap<K, V> {
+///   simple_keyed_ref!();
+/// }
+/// ```
+#[macro_export]
+macro_rules! simple_keyed_ref {
+	() => {
+		fn into_ref<'r>(r: Self::KeyRef<'r>) -> &'r Self::Key
+		where
+			Self: 'r,
+		{
+			r
+		}
+	};
+}


### PR DESCRIPTION
There are existing `SimpleCollectionRef` and `SimpleCollectionMut` for simple `&Item` and `&mut Item` borrows respectively. But this trait is missing for `KeyedRef`, so this PR adds `SimpleKeyedRef`.

Furthermore, the implementations are all the same for each of these `SimpleXxx` traits, so I've added macros to implement them for convenience.

<!-- 

/// Helper traits for [`cc_traits`], single trait for e.g. `KeyRef<'a> = &'a Key`, etc.
macro_rules! refed {
    ($item_ref:ident, $collection_ref:ident, $collection:ident, $item:ident $(, $mut:tt)?) => {
        #[doc = concat!("Helper trait for `", stringify!($item_ref), "<'a> = &'a ", $( stringify!($mut), " ", )? stringify!($item), "`.")]
        #[doc = ""]
        #[doc = concat!(
            "(Or, more verbosely: `for<'a> ", stringify!($collection), "<", stringify!($item_ref),
            "<'a> = &'a ", $( stringify!($mut), " ", )? "<Self as ", stringify!($collection),">::", stringify!($item), ">`).",
        )]
        #[sealed]
        pub trait $item_ref: 'static + for<'a> $collection_ref<$item_ref<'a> = &'a $( $mut )? <Self as $collection>::$item> {}
        #[sealed]
        impl<This> $item_ref for This where for<'a> This: 'a + $collection_ref<$item_ref<'a> = &'a $( $mut )? <Self as $collection>::$item> {}
    };
}
refed!(ItemRef, CollectionRef, Collection, Item);
refed!(ItemMut, CollectionMut, Collection, Item, mut);
refed!(KeyRef, KeyedRef, Keyed, Key);

-->