### PR TITLE
Std Capacity impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `no_std`.
 - Add "alloc" feature. Enables `alloc` collection implementations.
   Enabled by default.
+- `WithCapacity`, `Capacity` and `Reserve` impls for `HashMap` and `HashSet`.
 
 ## [1.0.0] - 2022-11-07
 ### Changed

--- a/src/impls/std/hashmap.rs
+++ b/src/impls/std/hashmap.rs
@@ -1,7 +1,7 @@
 use crate::{
-	Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetMut, Iter, Keyed,
-	KeyedRef, Len, MapInsert, MapIter, MapIterMut, Remove, SimpleCollectionMut,
-	SimpleCollectionRef, SimpleKeyedRef,
+	Capacity, Clear, Collection, CollectionMut, CollectionRef, Get, GetKeyValue, GetMut, Iter,
+	Keyed, KeyedRef, Len, MapInsert, MapIter, MapIterMut, Remove, Reserve, SimpleCollectionMut,
+	SimpleCollectionRef, SimpleKeyedRef, WithCapacity,
 };
 use std::{borrow::Borrow, collections::HashMap, hash::Hash};
 
@@ -43,6 +43,13 @@ impl<K, V> SimpleKeyedRef for HashMap<K, V> {
 	crate::simple_keyed_ref!();
 }
 
+impl<K, V> WithCapacity for HashMap<K, V> {
+	#[inline(always)]
+	fn with_capacity(capacity: usize) -> Self {
+		HashMap::with_capacity(capacity)
+	}
+}
+
 impl<K, V> Len for HashMap<K, V> {
 	#[inline(always)]
 	fn len(&self) -> usize {
@@ -63,6 +70,20 @@ where
 	#[inline(always)]
 	fn get(&self, key: &'a Q) -> Option<&V> {
 		self.get(key)
+	}
+}
+
+impl<K, V> Capacity for HashMap<K, V> {
+	#[inline(always)]
+	fn capacity(&self) -> usize {
+		self.capacity()
+	}
+}
+
+impl<K: Hash + Eq, V> Reserve for HashMap<K, V> {
+	#[inline(always)]
+	fn reserve(&mut self, additional: usize) {
+		self.reserve(additional)
 	}
 }
 

--- a/src/impls/std/hashset.rs
+++ b/src/impls/std/hashset.rs
@@ -1,6 +1,6 @@
 use crate::{
-	Clear, Collection, CollectionMut, CollectionRef, Get, Insert, Iter, Len, Remove,
-	SimpleCollectionMut, SimpleCollectionRef,
+	Capacity, Clear, Collection, CollectionMut, CollectionRef, Get, Insert, Iter, Len, Remove,
+	Reserve, SimpleCollectionMut, SimpleCollectionRef, WithCapacity,
 };
 use std::{borrow::Borrow, collections::HashSet, hash::Hash};
 
@@ -28,6 +28,13 @@ impl<T> SimpleCollectionMut for HashSet<T> {
 	crate::simple_collection_mut!();
 }
 
+impl<T> WithCapacity for HashSet<T> {
+	#[inline(always)]
+	fn with_capacity(capacity: usize) -> Self {
+		HashSet::with_capacity(capacity)
+	}
+}
+
 impl<T> Len for HashSet<T> {
 	#[inline(always)]
 	fn len(&self) -> usize {
@@ -47,6 +54,20 @@ where
 {
 	fn get(&self, value: &'a Q) -> Option<&T> {
 		self.get(value)
+	}
+}
+
+impl<T> Capacity for HashSet<T> {
+	#[inline(always)]
+	fn capacity(&self) -> usize {
+		self.capacity()
+	}
+}
+
+impl<T: Hash + Eq> Reserve for HashSet<T> {
+	#[inline(always)]
+	fn reserve(&mut self, additional: usize) {
+		self.reserve(additional)
 	}
 }
 


### PR DESCRIPTION
Implements `WithCapacity` + `Capacity` + `Reserve` for `HashMap` and `HashSet`.

I'm not sure if there was a reason these weren't implemented, but I _believe_ that this shouldn't cause any issues with regard to the `std` and `alloc` features since `HashMap` and `HashSet` are gated behind `std`

(great crate btw, thanks for maintaining!)